### PR TITLE
feat(mana-forge): add ManaBox selection CSV support to compare page

### DIFF
--- a/apps/mana-forge/src/components/text-drop-zone.tsx
+++ b/apps/mana-forge/src/components/text-drop-zone.tsx
@@ -21,7 +21,7 @@ export const TextDropZone: FC = () => {
     },
     multiple: true,
     useFsAccessApi: false,
-    accept: { "text/plain": [".txt"] },
+    accept: { "text/plain": [".txt"], "text/csv": [".csv"] },
   });
 
   return (
@@ -48,13 +48,13 @@ export const TextDropZone: FC = () => {
             size="xl"
             className={cn("text-balance")}
           >
-            Drag collection TXT files here or click to select
+            Drag TXT or CSV files here or click to select
           </Text>
           <Text
             size="sm"
             c="dimmed"
           >
-            Attach multiple files in Archidekt format
+            Archidekt TXT format or ManaBox CSV selection export
           </Text>
         </div>
       </button>

--- a/apps/mana-forge/src/stores/compare.store.ts
+++ b/apps/mana-forge/src/stores/compare.store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import type { Card } from "../utils/card.ts";
 import { cardKey, parseCollectionFile } from "../utils/card.ts";
+import { parseManaBoxSelectionCsv } from "../utils/manabox-csv.ts";
 
 export interface TextFile {
   name: string;
@@ -128,7 +129,11 @@ export const useCompareStore = create<CompareStore>()(
 
     compare: () =>
       set((state) => {
-        const lists = state.files.map((f) => parseCollectionFile(f.content));
+        const lists = state.files.map((f) =>
+          f.name.endsWith(".csv")
+            ? parseManaBoxSelectionCsv(f.content)
+            : parseCollectionFile(f.content),
+        );
         state.result = compareCards(lists);
       }),
 

--- a/apps/mana-forge/src/stores/split.store.ts
+++ b/apps/mana-forge/src/stores/split.store.ts
@@ -1,9 +1,9 @@
 import Papa from "papaparse";
-import z from "zod";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import type { Card } from "../utils/card.ts";
 import { cardKey } from "../utils/card.ts";
+import { manaBoxCollectionRowSchema } from "../utils/manabox-csv.ts";
 
 interface SplitStore {
   assignments: Record<AssignmentId, Array<Binder>>;
@@ -40,7 +40,7 @@ export const useSplitStore = create<SplitStore>()(
         const binders: Record<string, Binder> = {};
 
         for (const row of parsed.data) {
-          const validRow = manaBoxRowSchema.parse(row);
+          const validRow = manaBoxCollectionRowSchema.parse(row);
           const binderName = validRow["Binder Name"];
           const binderId = `${binderName}${validRow["Binder Type"]}`;
 
@@ -144,16 +144,3 @@ export function mergeBinders(binders: Array<Binder>): Array<Card> {
 
   return Array.from(cardMap.values());
 }
-
-const manaBoxRowSchema = z.object({
-  "Binder Name": z.string(),
-  "Binder Type": z.enum(["binder", "deck", "list"]),
-  // biome-ignore lint/style/useNamingConvention: CSV header name from external ManaBox export format
-  Name: z.string(),
-  "Set code": z.string(),
-  "Collector number": z.string(),
-  // biome-ignore lint/style/useNamingConvention: CSV header name from external ManaBox export format
-  Foil: z.string().transform((raw) => raw === "foil"),
-  // biome-ignore lint/style/useNamingConvention: CSV header name from external ManaBox export format
-  Quantity: z.coerce.number(),
-});

--- a/apps/mana-forge/src/utils/manabox-csv.ts
+++ b/apps/mana-forge/src/utils/manabox-csv.ts
@@ -1,0 +1,37 @@
+import Papa from "papaparse";
+import z from "zod";
+import type { Card } from "./card.ts";
+
+export const manaBoxBaseRowSchema = z.object({
+  // biome-ignore lint/style/useNamingConvention: CSV header name from external ManaBox export format
+  Name: z.string(),
+  "Set code": z.string(),
+  "Collector number": z.string(),
+  // biome-ignore lint/style/useNamingConvention: CSV header name from external ManaBox export format
+  Foil: z.string().transform((raw) => raw === "foil"),
+  // biome-ignore lint/style/useNamingConvention: CSV header name from external ManaBox export format
+  Quantity: z.coerce.number(),
+});
+
+export const manaBoxCollectionRowSchema = manaBoxBaseRowSchema.extend({
+  "Binder Name": z.string(),
+  "Binder Type": z.enum(["binder", "deck", "list"]),
+});
+
+export function parseManaBoxSelectionCsv(content: string): Array<Card> {
+  const parsed = Papa.parse(content, { header: true, skipEmptyLines: true });
+  const cards: Array<Card> = [];
+
+  for (const row of parsed.data) {
+    const validRow = manaBoxBaseRowSchema.parse(row);
+    cards.push({
+      quantity: validRow.Quantity,
+      name: validRow.Name,
+      setCode: validRow["Set code"],
+      collectorNumber: validRow["Collector number"],
+      foil: validRow.Foil,
+    });
+  }
+
+  return cards;
+}

--- a/apps/mana-forge/src/utils/manabox-csv.ts
+++ b/apps/mana-forge/src/utils/manabox-csv.ts
@@ -2,7 +2,7 @@ import Papa from "papaparse";
 import z from "zod";
 import type { Card } from "./card.ts";
 
-export const manaBoxBaseRowSchema = z.object({
+const manaBoxBaseRowSchema = z.object({
   // biome-ignore lint/style/useNamingConvention: CSV header name from external ManaBox export format
   Name: z.string(),
   "Set code": z.string(),


### PR DESCRIPTION
## Summary

- Extract shared ManaBox base row schema into `utils/manabox-csv.ts`; collection schema (`manaBoxCollectionRowSchema`) extends it via Zod `.extend()`, removing duplication from `split.store.ts`
- Add `parseManaBoxSelectionCsv` for the selection/binder/deck export format (no `Binder Name`/`Binder Type`, extra fields like `Scryfall ID` stripped by default)
- Compare store detects `.csv` extension and routes to the new parser; `.txt` files continue using `parseCollectionFile`
- Drop zone now accepts both `.txt` and `.csv`, UI text updated accordingly

## Test plan

- [ ] Drop a ManaBox selection CSV export + an Archidekt TXT file onto the compare drop zone and click Compare — results should show matches
- [ ] Drop two TXT files — existing behaviour unchanged
- [ ] Run `npx turbo test --filter=mana-forge` — all 39 tests pass
- [ ] Run `npm run lint:check` and `npx turbo ts:check` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)